### PR TITLE
Adding sample data disclaimer

### DIFF
--- a/ai-builder-docs/form-processing-sample-data.md
+++ b/ai-builder-docs/form-processing-sample-data.md
@@ -15,7 +15,10 @@ ms.reviewer: v-dehaas
 
 [!INCLUDE[cc-beta-prerelease-disclaimer](./includes/cc-beta-prerelease-disclaimer.md)]
 
-To explore the possibilities of form processing, you can get started by building and training a form processing model using  [sample invoices](https://go.microsoft.com/fwlink/?linkid=2103171). 
+To explore the possibilities of form processing, you can get started by building and training a form processing model using  [sample invoices](https://go.microsoft.com/fwlink/?linkid=2103171).
+
+> [!NOTE]
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
 
 ## Get the sample data
 

--- a/ai-builder-docs/form-processing-sample-data.md
+++ b/ai-builder-docs/form-processing-sample-data.md
@@ -18,7 +18,7 @@ ms.reviewer: v-dehaas
 To explore the possibilities of form processing, you can get started by building and training a form processing model using  [sample invoices](https://go.microsoft.com/fwlink/?linkid=2103171).
 
 > [!NOTE]
-> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when you create your database.
 
 ## Get the sample data
 

--- a/ai-builder-docs/object-detection-sample-data.md
+++ b/ai-builder-docs/object-detection-sample-data.md
@@ -18,7 +18,7 @@ ms.reviewer: v-dehaas
 To explore the possibilities of object detection in AI Builder, you can get started by building and training an object detection model using sample pictures and labels.
 
 > [!NOTE]
-> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when you create your database.
 
 ## Get the sample data
 

--- a/ai-builder-docs/object-detection-sample-data.md
+++ b/ai-builder-docs/object-detection-sample-data.md
@@ -17,6 +17,9 @@ ms.reviewer: v-dehaas
 
 To explore the possibilities of object detection in AI Builder, you can get started by building and training an object detection model using sample pictures and labels.
 
+> [!NOTE]
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+
 ## Get the sample data
 
 Download [AIBuilder_Lab.zip](https://go.microsoft.com/fwlink/?linkid=2103171) file, which contains object detection sample images and labels.

--- a/ai-builder-docs/prediction-sample-data.md
+++ b/ai-builder-docs/prediction-sample-data.md
@@ -15,6 +15,9 @@ ms.reviewer: v-dehaas
 
 To explore the possibilities of prediction in AI Builder, you can get started by building and training an prediction model using sample data provided by Microsoft.
 
+> [!NOTE]
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+
 ## Get the sample data
 
 You can [configure your new environment](build-model.md) to deploy sample data automatically when you create it. Or, you can use the AI Builder samples provided by Microsoft and stored [here](https://github.com/microsoft/PowerApps-Samples/tree/master/ai-builder).  Follow the instructions in the [Data preparation](prediction-data-prep.md) topic to import the sample data into your Common Data Service environment, and then follow the [Create a prediction model](prediction-create-model.md) instructions to create an AI model using this sample data.

--- a/ai-builder-docs/prediction-sample-data.md
+++ b/ai-builder-docs/prediction-sample-data.md
@@ -16,7 +16,7 @@ ms.reviewer: v-dehaas
 To explore the possibilities of prediction in AI Builder, you can get started by building and training an prediction model using sample data provided by Microsoft.
 
 > [!NOTE]
-> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when you create your database.
 
 ## Get the sample data
 

--- a/ai-builder-docs/text-classification-sample-data.md
+++ b/ai-builder-docs/text-classification-sample-data.md
@@ -17,6 +17,9 @@ ms.reviewer: v-dehaas
 
 To explore the possibilities of text classification in AI Builder, you can get started by building and training an text classification model using sample data. The sample data we provide uses customer feedback for a hospital. The goal would be to train a model that would be able to automatically predict categories for new incoming feedback. This could be used to help the hospital administrator free up time from categorizing patient feedback to act on it and offer a better experience to patients.
 
+> [!NOTE]
+> This sample data is added to your environment automatically if you enable the [Deploy sample apps and data](build-model.md#deploy-sample-apps-and-data) setting when creating your database.
+
 ## Set up an environment with data
 
 1. Download [AIBuilder_Lab.zip](https://go.microsoft.com/fwlink/?linkid=2103171) file, which contains text classification sample data.


### PR DESCRIPTION
There are two ways you can get sample data today: by enabling the "Deploy sample apps and data" setting when creating a database for your environment, or by downloading the ZIP file and manually importing them into your environment.

We encountered a user who had already deployed the sample data to their environment, and then tried to import the sample data to that same environment. Unfortunately, the error message they receive isn't very helpful as it's generic, so we wanted to provide an additional disclaimer in the documentation that states the sample data you can download is the same as the data that is deployed to your environment.