### PR TITLE
Removed Trove application

### DIFF
--- a/ai-builder-docs/collect-images.md
+++ b/ai-builder-docs/collect-images.md
@@ -78,12 +78,6 @@ AI models can incorrectly learn characteristics that your images have in common.
 
 To correct this, use the above guidance on training with more varied images: provide images with different angles, backgrounds, object size, groups, and other variants.
 
-## Need help collecting images?
-
-You can use [Trove](https://www.microsoft.com/ai/trove?activetab=pivot1:primaryr3) to gather images for your projects. Trove is an app that connects you directly with photo takers, allowing you to collect more relevant and accurate photos. Using Trove, you can post your project descriptions, outline the types of photos you are looking for, and only approve the photos that you want. Trove provides licensing and privacy frameworks, so you can collect high quality data responsibly and safely. 
-
-To use Trove, [sign up and add your AI project](https://aka.ms/t-aib).
-
 ### Next step
 
 [Get started with object detection](get-started-with-object-detection.md)


### PR DESCRIPTION
The Trove Application seems to be outdated. The URL to the application redirects to general AI and the form for registering your application does not exist anymore

Changes made in https://github.com/MicrosoftDocs/ai-builder-pr/pull/735. Ashish Bhatia approved.