### PR TITLE
content and contentBytes confusion fix

### DIFF
--- a/ai-builder-docs/flow-text-recognition.md
+++ b/ai-builder-docs/flow-text-recognition.md
@@ -26,7 +26,7 @@ To initialize your cloud flow, follow these steps:
 1. Name your cloud flow, select **Manually trigger a flow** under **Choose how to trigger this flow**, and then select **Create**.
 1. Expand **Manually trigger a flow**, and then select **+Add an input** > **File** as the input type.
 1. Select **+New step** > **AI Builder**, and then select **Recognize text in an image or a PDF document** in the list of actions.
-1. Select the **Image** input, and then select **File Content** from the **Dynamic content** list:
+1. Select the **File** input, and then select **File Content.contentBytes** from the **Dynamic content** list:
 
     :::image type="content" source="media/trigger-text-recognition-2.png" alt-text="Screenshot of initializing a Power Automate cloud flow in the 'Parameters' tab.":::
 


### PR DESCRIPTION
file content and contentBytes are actually two different things in power automate. the _Recognize text in an image or a PDF document_ activity accepts the "contentBytes" not the "file content". it was incorrectly mentioned here to pass the "file content".
<img width="561" height="418" alt="image" src="https://github.com/user-attachments/assets/f340f179-dda4-4bf1-a91e-ebda97d7a504" />
